### PR TITLE
Updated link for InversifyJS middleware docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ container.applyMiddleware(logger);
 ```
 
 Please refere to the
-[InversifyJS documentation](https://github.com/inversify/InversifyJS#middleware)
+[InversifyJS documentation](https://github.com/inversify/InversifyJS/blob/master/wiki/middleware.md)
 to learn more about middleware.
 
 ### Demo app


### PR DESCRIPTION
# Middleware link update

## Description

InversifyJS middleware docs changed from https://github.com/inversify/InversifyJS#middleware to https://github.com/inversify/InversifyJS/blob/master/wiki/middleware.md

Additionally, "Demo app" link to https://github.com/inversify/inversify-code-samples/tree/master/inversify-binding-decorator no longer works, but I'm not sure if https://github.com/inversify/inversify-binding-decorators is a good replacement as it's not provided as a "demo app".

## How Has This Been Tested

Doc change

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
